### PR TITLE
Make element hashable

### DIFF
--- a/ele/element.py
+++ b/ele/element.py
@@ -47,6 +47,12 @@ class Element(namedtuple("Element", "atomic_number, name, symbol, mass")):
             self.name, self.symbol, self.atomic_number, self.mass
         )
 
+    def __hash__(self):
+        return hash((self.name, self.symbol,
+                     self.atomic_number, self.mass))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
 def element_from_symbol(symbol):
     """Search for an element by its symbol

--- a/ele/tests/test_element.py
+++ b/ele/tests/test_element.py
@@ -101,3 +101,8 @@ class TestElement(BaseTest):
     def test_elements_enum(self):
         for key, val in Elements.symbols_dict.items():
             assert getattr(Elements, key) == val
+
+    def test_hash(self):
+        test_set = set()
+        for symbol in Elements.symbols_dict:
+            test_set.add(Elements.symbols_dict[symbol])


### PR DESCRIPTION
Add `__eq__` and `__hash__` to Element. The main purpose of this is to make `Element` hashable (and hence can be used as a key in a `dict` or added to a `set`)