### PR TITLE
Add IUPAC names for elements 113, 115, 117, 118.

### DIFF
--- a/ele/lib/elements.json
+++ b/ele/lib/elements.json
@@ -671,9 +671,9 @@
     "atomic number": 112,
     "mass": 285.0
   },
-  "ununtrium": {
-    "name": "ununtrium",
-    "symbol": "Uut",
+  "nihonium": {
+    "name": "nihonium",
+    "symbol": "Nh",
     "atomic number": 113,
     "mass": 286.0
   },
@@ -683,9 +683,9 @@
     "atomic number": 114,
     "mass": 289.0
   },
-  "ununpentium": {
-    "name": "ununpentium",
-    "symbol": "Uup",
+  "moscovium": {
+    "name": "moscovium",
+    "symbol": "Mc",
     "atomic number": 115,
     "mass": 289.0
   },
@@ -695,15 +695,15 @@
     "atomic number": 116,
     "mass": 291.0
   },
-  "ununseptium": {
-    "name": "ununseptium",
-    "symbol": "Uus",
+  "tennessine": {
+    "name": "tennessine",
+    "symbol": "Ts",
     "atomic number": 117,
     "mass": 293.0
   },
-  "ununoctium": {
-    "name": "ununoctium",
-    "symbol": "Uuo",
+  "oganesson": {
+    "name": "oganesson",
+    "symbol": "Og",
     "atomic number": 118,
     "mass": 294.0
   }


### PR DESCRIPTION
@rsdefever I added IUPAC names for elements 113, 115, 117, 118. (Don't take this PR too seriously, I did it just for fun.)

Source: https://iupac.org/iupac-announces-the-names-of-the-elements-113-115-117-and-118/

I left the atomic masses unchanged since I was unable to find definitive sources (so few isotopes have been seen). For example, Wikipedia [states](https://en.wikipedia.org/wiki/Nihonium) "Eight different isotopes of nihonium have been reported with atomic masses 278, 282–287, and 290."

As a sort-of-related suggestion, it might make sense to use the atomic number as the primary key of the JSON dictionary instead of the atomic name, since multiple names (e.g. recently named elements) or multiple spellings ([IUPAC prefers the spelling "aluminium" over "aluminum"](https://en.wikipedia.org/wiki/Aluminium#Spelling)) could be found that way.