### PR TITLE
Add/element inference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ na = ele.element_from_mass(22.990)
 
 The mass is rounded to a one digit after the decimal before comparison. If you wish to
 retrieve the element with the mass closest to the specified value you
-may use the `exact=False` keyword. In all cases, not match results
+may use the `exact=False` keyword. In all cases, no matches results
 in an `ElementError`.
 
 **Ele** also offers a function to infer an element from a string with

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,24 @@ na = ele.element_from_atomic_number(11)
 na = ele.element_from_mass(22.990)
 ```
 
-The mass is rounded to a single decimal before comparison. If you wish to
+The mass is rounded to a one digit after the decimal before comparison. If you wish to
 retrieve the element with the mass closest to the specified value you
-may use the `exact=False` keyword.
+may use the `exact=False` keyword. In all cases, not match results
+in an `ElementError`.
+
+**Ele** also offers a function to infer an element from a string with
+well-defined behavior:
+
+```python
+import ele
+na = ele.infer_element_from_string("Na")
+na = ele.infer_element_from_string("sodium")
+```
+
+`infer_element_from_string` first checks if the string matches a
+two-character element symbol. If not, it then checks if the string
+matches a full element name. The function returns the matching element.
+If there is no matching element, an `ElementError` is raised.
 
 Each `Element` has four attributes which can be accessed
 (as demonstrated below for ``na``):

--- a/ele/__init__.py
+++ b/ele/__init__.py
@@ -2,6 +2,7 @@ from .element import element_from_symbol
 from .element import element_from_name
 from .element import element_from_atomic_number
 from .element import element_from_mass
+from .element import infer_element_from_string
 from .element import Elements
 
 __version__ = "0.1.0"
@@ -12,5 +13,6 @@ __all__ = [
     "element_from_name",
     "element_from_atomic_number",
     "element_from_mass",
+    "infer_element_from_string",
     "Elements",
 ]

--- a/ele/element.py
+++ b/ele/element.py
@@ -72,7 +72,7 @@ def element_from_symbol(symbol):
         otherwise return None
     """
     if not isinstance(symbol, str):
-        raise TypeError("`symbol` ({symbol}) must be a string")
+        raise TypeError(f"`symbol` ({symbol}) must be a string")
 
     symbol = symbol.capitalize()
     matched_element = symbol_dict.get(symbol)
@@ -100,7 +100,7 @@ def element_from_name(name):
         otherwise return None
     """
     if not isinstance(name, str):
-        raise TypeError("`name` ({name}) must be a string")
+        raise TypeError(f"`name` ({name}) must be a string")
 
     name = name.lower()
     matched_element = name_dict.get(name)
@@ -126,7 +126,7 @@ def element_from_atomic_number(atomic_number):
         Return an element from the periodic table if we find a match,
     """
     if not isinstance(atomic_number, int):
-        raise TypeError("`atomic_number` ({atomic_number}) must be an int")
+        raise TypeError(f"`atomic_number` ({atomic_number}) must be an int")
 
     matched_element = atomic_dict.get(atomic_number)
     if matched_element is None:
@@ -191,6 +191,38 @@ def element_from_mass(mass, exact=True, duplicates="error"):
             matched_element = tuple(matched_element)
         elif duplicates.lower() == "none":
             matched_element = None
+
+    return matched_element
+
+
+def infer_element_from_string(string):
+    """Attempt to infer an element from a string
+
+    First checks if the string matches a two-character
+    element symbol. If not, checks if the string matches
+    an element name. If not, raises an ElementError
+
+    Parameters
+    ----------
+    string : str
+        String to attempt element inference from
+
+    Returns
+    -------
+    matched_element : element.Element
+        Return the matching element from the periodict table
+    """
+    if not isinstance(string, str):
+        raise TypeError(f"`string` ({string}) must be a string")
+
+    symbol = string.capitalize()
+    matched_element = symbol_dict.get(symbol)
+    if matched_element is None:
+        name = string.lower()
+        matched_element = name_dict.get(name)
+
+    if matched_element is None:
+        raise ElementError(f"Cannot infer element from '{string}'")
 
     return matched_element
 

--- a/ele/element.py
+++ b/ele/element.py
@@ -71,7 +71,7 @@ def element_from_symbol(symbol):
         The matching element from the periodic table
     """
     if not isinstance(symbol, str):
-        raise TypeError(f"`symbol` ({symbol}) must be a string")
+        raise TypeError("`symbol` ({symbol}) must be a string")
 
     symbol = symbol.capitalize()
     matched_element = symbol_dict.get(symbol)
@@ -98,7 +98,7 @@ def element_from_name(name):
         The matching element from the periodic table
     """
     if not isinstance(name, str):
-        raise TypeError(f"`name` ({name}) must be a string")
+        raise TypeError("`name` ({name}) must be a string")
 
     name = name.lower()
     matched_element = name_dict.get(name)
@@ -125,7 +125,7 @@ def element_from_atomic_number(atomic_number):
         The matching element from the periodic table
     """
     if not isinstance(atomic_number, int):
-        raise TypeError(f"`atomic_number` ({atomic_number}) must be an int")
+        raise TypeError("`atomic_number` ({atomic_number}) must be an int")
 
     matched_element = atomic_dict.get(atomic_number)
     if matched_element is None:
@@ -202,7 +202,7 @@ def infer_element_from_string(string):
 
     First checks if the string matches a two-character
     element symbol. If not, checks if the string matches
-    an element name. Raises an ElementError if no match is found.
+    an element name.
 
     Parameters
     ----------
@@ -213,9 +213,16 @@ def infer_element_from_string(string):
     -------
     matched_element : element.Element
         The matching element from the periodic table
+
+    Raises
+    ------
+    ElementError
+        If no match is found
     """
     if not isinstance(string, str):
-        raise TypeError(f"`string` ({string}) must be a string")
+        raise TypeError(
+            f"`string` ({string}) must be a string.  Provided {type(string).__name__}"
+        )
 
     try:
         matched_element = element_from_symbol(string)

--- a/ele/element.py
+++ b/ele/element.py
@@ -217,14 +217,13 @@ def infer_element_from_string(string):
     if not isinstance(string, str):
         raise TypeError(f"`string` ({string}) must be a string")
 
-    symbol = string.capitalize()
-    matched_element = symbol_dict.get(symbol)
-    if matched_element is None:
-        name = string.lower()
-        matched_element = name_dict.get(name)
-
-    if matched_element is None:
-        raise ElementError(f"Cannot infer element from '{string}'")
+    try:
+        matched_element = element_from_symbol(string)
+    except ElementError:
+        try:
+            matched_element = element_from_name(string)
+        except ElementError:
+            raise ElementError(f"Unable to match {string} with element name or symbol")
 
     return matched_element
 

--- a/ele/element.py
+++ b/ele/element.py
@@ -58,7 +58,6 @@ def element_from_symbol(symbol):
     """Search for an element by its symbol
 
     Look up an element from a list of known elements by symbol.
-    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -69,6 +68,11 @@ def element_from_symbol(symbol):
     -------
     matched_element : element.Element
         The matching element from the periodic table
+
+    Raises
+    ------
+    ElementError
+        If no match is found
     """
     if not isinstance(symbol, str):
         raise TypeError("`symbol` ({symbol}) must be a string")
@@ -85,7 +89,6 @@ def element_from_name(name):
     """Search for an element by its name
 
     Look up an element from a list of known elements by name.
-    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -96,6 +99,11 @@ def element_from_name(name):
     -------
     matched_element : element.Element
         The matching element from the periodic table
+
+    Raises
+    ------
+    ElementError
+        If no match is found
     """
     if not isinstance(name, str):
         raise TypeError("`name` ({name}) must be a string")
@@ -112,7 +120,6 @@ def element_from_atomic_number(atomic_number):
     """Search for an element by its atomic number
 
     Look up an element from a list of known elements by atomic number.
-    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -123,6 +130,11 @@ def element_from_atomic_number(atomic_number):
     -------
     matched_element : element.Element
         The matching element from the periodic table
+
+    Raises
+    ------
+    ElementError
+        If no match is found
     """
     if not isinstance(atomic_number, int):
         raise TypeError("`atomic_number` ({atomic_number}) must be an int")

--- a/ele/element.py
+++ b/ele/element.py
@@ -58,7 +58,7 @@ def element_from_symbol(symbol):
     """Search for an element by its symbol
 
     Look up an element from a list of known elements by symbol.
-    Return None if no match found.
+    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -68,8 +68,7 @@ def element_from_symbol(symbol):
     Returns
     -------
     matched_element : element.Element
-        Return an element from the periodic table if the symbol is found,
-        otherwise return None
+        The matching element from the periodic table
     """
     if not isinstance(symbol, str):
         raise TypeError(f"`symbol` ({symbol}) must be a string")
@@ -86,7 +85,7 @@ def element_from_name(name):
     """Search for an element by its name
 
     Look up an element from a list of known elements by name.
-    Return None if no match found.
+    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -96,8 +95,7 @@ def element_from_name(name):
     Returns
     -------
     matched_element : element.Element
-        Return an element from the periodic table if the name is found,
-        otherwise return None
+        The matching element from the periodic table
     """
     if not isinstance(name, str):
         raise TypeError(f"`name` ({name}) must be a string")
@@ -114,6 +112,7 @@ def element_from_atomic_number(atomic_number):
     """Search for an element by its atomic number
 
     Look up an element from a list of known elements by atomic number.
+    Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -123,7 +122,7 @@ def element_from_atomic_number(atomic_number):
     Returns
     -------
     matched_element : element.Element
-        Return an element from the periodic table if we find a match,
+        The matching element from the periodic table
     """
     if not isinstance(atomic_number, int):
         raise TypeError(f"`atomic_number` ({atomic_number}) must be an int")
@@ -139,6 +138,10 @@ def element_from_mass(mass, exact=True, duplicates="error"):
     """Search for an element by its mass
 
     Look up an element from a list of known elements by mass (amu).
+    By default, requires that the element mass match exactly
+    to the first digit after the decimal. Using `exact=False`
+    will switch this behavior to return the element with the
+    closest mass.
 
     Parameters
     ----------
@@ -155,8 +158,7 @@ def element_from_mass(mass, exact=True, duplicates="error"):
     Returns
     -------
     matched_element : element.Element or tuple of element.Element
-        Return an element from the periodict table if we find a match,
-        otherwise return None
+        The matching element(s) from the periodic table
     """
     if not isinstance(mass, (float, int)):
         raise TypeError("`mass` ({mass}) must be a float")
@@ -200,7 +202,7 @@ def infer_element_from_string(string):
 
     First checks if the string matches a two-character
     element symbol. If not, checks if the string matches
-    an element name. If not, raises an ElementError
+    an element name. Raises an ElementError if no match is found.
 
     Parameters
     ----------
@@ -210,7 +212,7 @@ def infer_element_from_string(string):
     Returns
     -------
     matched_element : element.Element
-        Return the matching element from the periodict table
+        The matching element from the periodic table
     """
     if not isinstance(string, str):
         raise TypeError(f"`string` ({string}) must be a string")

--- a/ele/tests/test_element.py
+++ b/ele/tests/test_element.py
@@ -4,6 +4,7 @@ from ele import element_from_symbol
 from ele import element_from_name
 from ele import element_from_atomic_number
 from ele import element_from_mass
+from ele import infer_element_from_string
 from ele import Elements
 
 from ele.tests.base_test import BaseTest
@@ -86,6 +87,24 @@ class TestElement(BaseTest):
             na = element_from_mass(22.99, duplicates="tuple")
         with pytest.raises(MultiMatchError):
             fl = element_from_mass(289.0)
+
+    def test_invalid_element_from_string(self):
+        with pytest.raises(TypeError):
+            infer_element_from_string(22)
+
+    def test_unmatched_element_from_string(self):
+        with pytest.raises(ElementError):
+            infer_element_from_string("compound")
+
+    def test_infer_element_from_string(self):
+        f = infer_element_from_string("F")
+        assert f == Elements.F
+
+        c = infer_element_from_string("carbon")
+        assert c == Elements.C
+
+        cl = infer_element_from_string("Chlorine")
+        assert cl == Elements.Cl
 
     def test_element_attributes(self):
         na = element_from_mass(22.98)


### PR DESCRIPTION
Adds a new function, `infer_element_from_string` which introduces the following element inference behavior:
1. Check if `string` matches a two-character element symbol
2. If not, check if `string` matches a full element name
3. If not, raise an `ElementError`.
4. Return the matching element.

This functionality makes it easier to infer elements from a string when it is unknown if the string is a symbol or full element name.

There are also some updates/corrections to the docstrings of the other functions.

Appropriate edits to the docs are included.

Closes #39. 